### PR TITLE
Fix TCP out of order

### DIFF
--- a/pcap_reassembler.py
+++ b/pcap_reassembler.py
@@ -34,6 +34,8 @@ _ip_protocol = {
     'UDP': '\x11',
 }
 
+FILL_BYTE = "\x00"
+
 class Message(dict):
     """Reassembled message class
 
@@ -212,6 +214,8 @@ class PcapReassembler:
             msg.fragment_tss.append(ts)
             msg.data.append(''.join(data))
             offset = seq - msg.seq
+            if offset > len(msg.payload):
+                msg.payload.extend(FILL_BYTE * (offset - len(msg.payload)))
             msg.payload[offset:offset+len(pld)] = list(pld)
         if self._strict_policy:
             # Check the other stream in the connection


### PR DESCRIPTION
When TCP packets in the PCAP aren't recorded in the right order, the
payload would become corrupted, because data was directly appended the
end of the current payload and no 'filling' was inserted.
This data would then later be overwritten by another chunk which would
be written to the correct position for this chunk (but the packet that
was out of order falsely occupied this offset beforehand).

The fix consists of extending the payload with zeroes, up to the
position where the current chunk belongs. These zeroes would then later
be overwritten by the data that belongs in this place (if the packet
arrives).

@daniel-plohmann helped discover this bug.

This bug was discovered when inspecting a PCAP from a Citadel Malware sample.
Here you can see 6 segments of TCP packets that are out of order: http://imgur.com/a/gkIxb
This led to exactly 6 holes in the payload from pcap-reassembler.
After applying the fix, it was assembled correctly.
